### PR TITLE
Update DHT22.py to attach DHT11 power pin to GPIO without sensor error

### DIFF
--- a/DHT22.py
+++ b/DHT22.py
@@ -132,7 +132,7 @@ class DHT22:
     def read_array(self):
         if self.powerPin is not None:
             self.powerPin.value(1)
-        utime.sleep_ms(100)
+        utime.sleep_ms(200)
         #start state machine
         self.sm.init(DHT22_PIO,freq=500000,
                      set_base=self.dataPin,
@@ -147,6 +147,8 @@ class DHT22:
         for i in range(5):
             value.append(self.sm.get())
         self.sm.active(0)
+		if self.powerPin is not None:
+            self.powerPin.value(0)
         return value
  
     def read(self):

--- a/DHT22.py
+++ b/DHT22.py
@@ -147,7 +147,7 @@ class DHT22:
         for i in range(5):
             value.append(self.sm.get())
         self.sm.active(0)
-		if self.powerPin is not None:
+        if self.powerPin is not None:
             self.powerPin.value(0)
         return value
  


### PR DESCRIPTION
**Thx for your lib, great work.**

I encountered a little problem when I decided to power off the sensor after reading the values in DHT22.read_array(). Adding 

```
if self.powerPin is not None:
    self.powerPin.value(0)
```
just before returning the value ended up in giving me a "sensor error" all the time.

I liked the approach to power off the sensor via a GPIO pin. However, delaying the start of the state machine by 100ms not enough, so I additionally increased the value from 100 to 200ms. Now the DHT11 responds correctly when trying the first time.
