### PR TITLE
additional sleep time after powering up DHTxx

### DIFF
--- a/DHT22.py
+++ b/DHT22.py
@@ -132,6 +132,7 @@ class DHT22:
     def read_array(self):
         if self.powerPin is not None:
             self.powerPin.value(1)
+            utime.sleep_ms(800)
         utime.sleep_ms(200)
         #start state machine
         self.sm.init(DHT22_PIO,freq=500000,


### PR DESCRIPTION
Datasheet states:
"When power is supplied to the sensor, do not send any instruction to the sensor in within one second in order to pass the unstable status."
So after poweing up the sensor using the powerPin wait an additional 800ms to stay within specs